### PR TITLE
Update symbolication server host

### DIFF
--- a/resymbolicate_activitymonitorsample.py
+++ b/resymbolicate_activitymonitorsample.py
@@ -15,7 +15,7 @@ gSymbolicationOptions = {
   # Trace-level logging (verbose)
   "enableTracing": 0,
   # Fallback server if symbol is not found locally
-  "remoteSymbolServer": "https://symbols.mozilla.org/symbolicate/v4",
+  "remoteSymbolServer": "https://symbolication.services.mozilla.com/symbolicate/v4",
   # Maximum number of symbol files to keep in memory
   "maxCacheEntries": 2000000,
   # Frequency of checking for recent symbols to cache (in hours)


### PR DESCRIPTION
This updates the symbolication server host from the deprecated one to the new one.

See bug #1839705.